### PR TITLE
Optimize power_next

### DIFF
--- a/gm82core.c
+++ b/gm82core.c
@@ -328,22 +328,6 @@ GMREAL string_token_start(const char* str, const char* sep) {
     return 0;
 }
 
-GMREAL power_next(double x) {
-    unsigned int v; // compute the next highest power of 2 of 32-bit v
-
-    v=(unsigned int)x;
-    
-    v--;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v++;
-    
-    return (double)v;
-}
-
 GMREAL point_line_lerp(double px, double py, double x1, double y1, double x2, double y2, double segment) {
     ///point_line_lerp(px,py,x1,y1,x2,y2,segment)
     //

--- a/lovey01.c
+++ b/lovey01.c
@@ -2,6 +2,19 @@
 
 #include "gm82core.h"
 
+GMREAL power_next(double x) {
+  // Type pune the double to manipulate it's floating-point bits
+  unsigned __int64 *v = (unsigned __int64*)&x;
+
+  // Bring the number up to the next power of 2, unless the number is already
+  // a power of 2
+  // If the number is negative, return 0
+  *v = (((*v + 0x000fffffffffffffui64) & 0x7ff0000000000000ui64) &
+        ~(unsigned __int64)((__int64)*v >> 63));
+
+  return x;
+}
+
 GMREAL file_size(const char *filename) {
     // Get size of file
     // Returns -1 if file doesn't exist


### PR DESCRIPTION
This PR optimizes power_next by manipulating floating-point bits instead of converting to an integer. It also comes with a much more robust power_next, returning 0 if x is < 0, supporting powers of 2 greater than 2^31, and supporting negative powers of 2 (`power_next(0.26) == 0.5`)

It's less readable, if that's a concern.