### PR TITLE
set_dll_loaddir as a visible function

### DIFF
--- a/gm82core.gej
+++ b/gm82core.gej
@@ -754,6 +754,17 @@
 					"returntype": 2
 				},
 				{
+					"name": "set_dll_loaddir",
+					"extname": "",
+					"calltype": 12,
+					"helpline": "set_dll_loaddir(directory)",
+					"hidden": false,
+					"argtypes": [
+						1
+					],
+					"returntype": 2
+				},
+				{
 					"name": "sleep_ext",
 					"extname": "",
 					"calltype": 12,


### PR DESCRIPTION
Because of someone's needs (mine), i wanna make `set_dll_loaddir` a visible function