### PR TITLE
Make `file_find_list()` add directories not reversed

### DIFF
--- a/source/system.gml
+++ b/source/system.gml
@@ -203,7 +203,7 @@
     //recursive: if the search should go into directories
     //returns: ds_list containing paths to all files found
     
-    var __root,__mask,__attr,__recursive,__excludedirs,__list,__folder,__folders,__fn;
+    var __root,__mask,__attr,__recursive,__excludedirs,__list,__folder,__folders,__fn,__i;
     
     __root=string_replace_all(argument0,"/","\")
     __mask=argument1
@@ -221,7 +221,7 @@
 
     __folder[0]=__root
     __folders=0
-    i=0
+    __i=0
 
     do {
         __root=__folder[__folders]+"\"
@@ -234,9 +234,9 @@
                     __folders+=1
                 }                 
             }
-            i+=1
+            __i+=1
         } file_find_close()
-    } until (i>=__folders)
+    } until (__i>=__folders)
 
     return __list
 

--- a/source/system.gml
+++ b/source/system.gml
@@ -220,10 +220,10 @@
     if (string_char_at(__root,string_length(__root))=="\") __root=string_copy(__root,1,string_length(__root)-1)
 
     __folder[0]=__root
-    __folders=1
+    __folders=0
+    i=0
 
     do {
-        __folders-=1
         __root=__folder[__folders]+"\"
         for (__file=file_find_first(__root+__mask,__attr);__file!="";__file=file_find_next()) {
             if (__file!="." && __file!="..") {
@@ -234,8 +234,9 @@
                     __folders+=1
                 }                 
             }
+            i+=1
         } file_find_close()
-    } until (__folders==0)
+    } until (i>=__folders)
 
     return __list
 

--- a/source/system.gml
+++ b/source/system.gml
@@ -221,7 +221,7 @@
     if (string_char_at(__root,string_length(__root))=="\") __root=string_copy(__root,1,string_length(__root)-1)
 
     __folder[0]=__root
-    __folders=0
+    __folders=1
     __i=0
 
     do {

--- a/source/system.gml
+++ b/source/system.gml
@@ -201,6 +201,7 @@
     //query: file mask to find
     //attr: 0, or any additional file attributes you might have interest in
     //recursive: if the search should go into directories
+    //excludedirs: exclude directories from adding to ds_list
     //returns: ds_list containing paths to all files found
     
     var __root,__mask,__attr,__recursive,__excludedirs,__list,__folder,__folders,__fn,__i;
@@ -224,7 +225,7 @@
     __i=0
 
     do {
-        __root=__folder[__folders]+"\"
+        __root=__folder[__i]+"\"
         for (__file=file_find_first(__root+__mask,__attr);__file!="";__file=file_find_next()) {
             if (__file!="." && __file!="..") {
                 __fn=__root+__file
@@ -234,8 +235,8 @@
                     __folders+=1
                 }                 
             }
-            __i+=1
         } file_find_close()
+        __i+=1
     } until (__i>=__folders)
 
     return __list


### PR DESCRIPTION
So i found a lil stupid bug in `file_find_list()`, example
i have five directories in `E:\!Music\OtherMusic\`, `500 is gggj\`, `agagga`, `hhh`, `UnityHackedEdition69.9` and `Yttrium`.
when i use `file_find_list()` for recursive file add, they are adding in backwards alphabetical order, like `Yttrium`, `UnityHackedEdition69.9` and counting.
i made a fix that will add directories in alphabetical order