### PR TITLE
add ds_map_write_ini_string

### DIFF
--- a/gm82core.gej
+++ b/gm82core.gej
@@ -2037,6 +2037,17 @@
 					"returntype": 2
 				},
 				{
+					"name": "ds_map_write_ini_string",
+					"extname": "",
+					"calltype": 2,
+					"helpline": "ds_map_write_ini_string(map)",
+					"hidden": false,
+					"argtypes": [
+						2
+					],
+					"returntype": 1
+				},
+				{
 					"name": "ds_priority_add_many",
 					"extname": "",
 					"calltype": 2,

--- a/source/data_structures.gml
+++ b/source/data_structures.gml
@@ -228,6 +228,26 @@
     
     return file_exists(argument1)
 
+#define ds_map_write_ini_string
+    ///ds_map_write_ini_string(map)
+    //map: ds map index
+    //Returns: ini formatted string
+    //Creates a ini formatted string from a dsmap. Spaces are used to split key sections.
+    var __map, __success, __tempFileName;
+    __tempFileName = "_temp.ini"
+    __map = argument0
+    __success = ds_map_write_ini(__map, __tempFileName)
+    
+    if (!__success) {
+        return ""
+    } 
+
+    var __string;
+    __string = file_text_read_all(__tempFileName)
+    sleep(1)
+    file_delete(__tempFileName)
+    return __string
+    
 
 #define ds_map_read_ini_string
     ///ds_map_read_ini_string(map,string)


### PR DESCRIPTION
Adds version of ds_map_write_ini that returns the contents of the file. This could be later made faster by avoiding creating the temporary ini file