### PR TITLE
make get_cpu_usage more accurate and move old metric to get_frametime_usage

### DIFF
--- a/gm82core.gej
+++ b/gm82core.gej
@@ -453,6 +453,15 @@
 					"returntype": 2
 				},
 				{
+					"name": "get_cpu_usage",
+					"extname": "",
+					"calltype": 12,
+					"helpline": "get_cpu_usage()",
+					"hidden": false,
+					"argtypes": [],
+					"returntype": 2
+				},
+				{
 					"name": "get_delta",
 					"extname": "hrt_delta",
 					"calltype": 12,
@@ -466,15 +475,6 @@
 					"extname": "",
 					"calltype": 12,
 					"helpline": "get_ram_usage()",
-					"hidden": false,
-					"argtypes": [],
-					"returntype": 2
-				},
-				{
-					"name": "get_cpu_usage",
-					"extname": "",
-					"calltype": 12,
-					"helpline": "get_cpu_usage()",
 					"hidden": false,
 					"argtypes": [],
 					"returntype": 2

--- a/gm82core.gej
+++ b/gm82core.gej
@@ -471,6 +471,15 @@
 					"returntype": 2
 				},
 				{
+					"name": "get_cpu_usage",
+					"extname": "",
+					"calltype": 12,
+					"helpline": "get_cpu_usage()",
+					"hidden": false,
+					"argtypes": [],
+					"returntype": 2
+				},
+				{
 					"name": "get_system_language",
 					"extname": "",
 					"calltype": 12,
@@ -4030,15 +4039,6 @@
 					"argtypes": [
 						2
 					],
-					"returntype": 2
-				},
-				{
-					"name": "get_cpu_usage",
-					"extname": "",
-					"calltype": 2,
-					"helpline": "get_cpu_usage()",
-					"hidden": false,
-					"argtypes": [],
 					"returntype": 2
 				},
 				{

--- a/gm82core.gej
+++ b/gm82core.gej
@@ -4042,6 +4042,15 @@
 					"returntype": 2
 				},
 				{
+					"name": "get_frametime_usage",
+					"extname": "",
+					"calltype": 2,
+					"helpline": "get_frametime_usage()",
+					"hidden": false,
+					"argtypes": [],
+					"returntype": 2
+				},
+				{
 					"name": "get_open_filename_ext",
 					"extname": "",
 					"calltype": 2,

--- a/source/system.gml
+++ b/source/system.gml
@@ -397,5 +397,13 @@
     if (argument0<0 or argument0>255) return chr(argument0)    
 
     return global.__gm82core_keynames[argument0]
+
+
+#define get_frametime_usage
+    ///get_frametime_usage()
+    //Returns an approximation of the amount of cpu time the game is occupying between frames.
+    //The precise calculation is how much of the allotted frame time is being spent not waiting for the next frame.
+    if (fps_real>0) return ceil(min(1,room_speed/fps_real)*100)
+    return 100
 //
 //

--- a/source/system.gml
+++ b/source/system.gml
@@ -347,14 +347,6 @@
     return frac(__phase)
 
 
-#define get_cpu_usage
-    ///get_cpu_usage()
-    //Returns an approximation of the amount of cpu time the game is occupying between frames.
-    //The precise calculation is how much of the allotted frame time is being spent not waiting for the next frame.
-    if (fps_real>0) return ceil(min(1,room_speed/fps_real)*100)
-    return 100
-
-
 #define extension_detect
     ///extension_detect(name)
     //Detects the presence of a gm82 extension by its name.

--- a/source/windows.c
+++ b/source/windows.c
@@ -498,3 +498,50 @@ GMREAL process_exists(const char* name) {
     
     return (double)found;
 }
+
+GMREAL get_cpu_usage() {
+    ///get_cpu_usage()
+    //returns: an approximate CPU usage percentage (0-100)
+    
+    static uint64_t last_sys_time = 0;
+    static uint64_t last_proc_time = 0;
+    static DWORD last_update_tick = 0;
+    static double last_cpu_usage = 0.0;
+    
+    DWORD current_tick = GetTickCount();
+    if (last_sys_time != 0 && (current_tick - last_update_tick) < 1000) {
+        return last_cpu_usage;
+    }
+    
+    FILETIME sysIdle, sysKernel, sysUser;
+    FILETIME creationTime, exitTime, procKernelTime, procUserTime;
+    
+    if (GetSystemTimes(&sysIdle, &sysKernel, &sysUser) &&
+        GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &procKernelTime, &procUserTime)) 
+    {
+        uint64_t sys_time = ((uint64_t)sysKernel.dwLowDateTime | ((uint64_t)sysKernel.dwHighDateTime << 32)) +
+                            ((uint64_t)sysUser.dwLowDateTime | ((uint64_t)sysUser.dwHighDateTime << 32));
+                            
+        uint64_t proc_time = ((uint64_t)procKernelTime.dwLowDateTime | ((uint64_t)procKernelTime.dwHighDateTime << 32)) +
+                             ((uint64_t)procUserTime.dwLowDateTime | ((uint64_t)procUserTime.dwHighDateTime << 32));
+                             
+        if (last_sys_time == 0) {
+            last_sys_time = sys_time;
+            last_proc_time = proc_time;
+            last_update_tick = current_tick;
+            return 0.0;
+        }
+        
+        uint64_t sys_diff = sys_time - last_sys_time;
+        uint64_t proc_diff = proc_time - last_proc_time;
+        
+        last_sys_time = sys_time;
+        last_proc_time = proc_time;
+        last_update_tick = current_tick;
+        
+        if (sys_diff > 0) {
+            last_cpu_usage = (double)(proc_diff * 100.0 / sys_diff);
+        }
+    }
+    return last_cpu_usage;
+}

--- a/source/windows.c
+++ b/source/windows.c
@@ -540,7 +540,12 @@ GMREAL get_cpu_usage() {
         last_update_tick = current_tick;
         
         if (sys_diff > 0) {
-            last_cpu_usage = (double)(proc_diff * 100.0 / sys_diff);
+            SYSTEM_INFO sysInfo;
+            GetSystemInfo(&sysInfo);
+            int num_processors = sysInfo.dwNumberOfProcessors;
+            if (num_processors == 0) num_processors = 1;
+            
+            last_cpu_usage = (double)(proc_diff * 100.0 * num_processors / sys_diff);
         }
     }
     return last_cpu_usage;


### PR DESCRIPTION
ported get_cpu_usage to winapi to get cpu usage, resembling the task manager's cpu usage. previously, the cpu usage was significantly higher than the real value, with discrepancies ranging from 2% to 6%
<img width="318" height="238" alt="image" src="https://github.com/user-attachments/assets/02ce905e-3f79-4433-b33d-9b3bc3579f4e" />
